### PR TITLE
Optionally depends on immutables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ python:
   - 3.5
   - 3.6
 
+env:
+  - USE_IMMUTABLES=no
+  - USE_IMMUTABLES=yes
+
+install:
+  - if [[ $USE_IMMUTABLES == 'yes' ]]; then pip install -e .[HAMT]; else pip install -e .; fi
+
 script:
-  - pip install -e .
   - python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,13 @@ PEP 567 Backport
 ================
 
 This package implements a backport of Python 3.7 ``contextvars``
-module (see PEP 567) for Python 3.6.
+module (see PEP 567) for Python 3.6 and 3.5.
+
+In Python 3.7, ``contextvars`` uses an immutable mapping type based
+on HAMT, which is backported to Python 3.6 and 3.5 as `immutables
+<https://github.com/MagicStack/immutables/>`_, and listed as an
+optional dependency here as ``HAMT``. It is boosted by C code in
+CPython like CPython 3.7, thus recommended for general use.
 
 **Important:** at this moment this package does not provide an
 asyncio event loop with PEP 567 support yet.  Stay tuned for updates.
@@ -35,7 +41,7 @@ Installation
 
 .. code-block:: bash
 
-    $ pip install contextvars
+    $ pip install contextvars[HAMT]
 
 
 Usage
@@ -56,7 +62,7 @@ Listing as a Dependency
 The good news is that the standard library always takes the
 precedence over site packages, so even if a local ``contextvars``
 module is installed, the one from the standard library will be used.
-Therefore you can simply list "contextvars" in your
+Therefore you can simply list ``contextvars[HAMT]`` in your
 ``requirements.txt`` or ``setup.py`` files.
 
 Another option is to use `"platform specific dependencies"
@@ -71,7 +77,7 @@ Another option is to use `"platform specific dependencies"
         name="Project",
         ...
         install_requires=[
-            'contextvars;python_version<"3.7"'
+            'contextvars[HAMT];python_version<"3.7"'
         ]
     )
 

--- a/contextvars/__init__.py
+++ b/contextvars/__init__.py
@@ -8,34 +8,37 @@ __all__ = ('ContextVar', 'Context', 'Token', 'copy_context')
 _NO_DEFAULT = object()
 
 
-class _ContextData:
+try:
+    from immutables import Map as _ContextData
+except ImportError:
+    class _ContextData:
 
-    def __init__(self):
-        self._mapping = dict()
+        def __init__(self):
+            self._mapping = dict()
 
-    def __getitem__(self, key):
-        return self._mapping[key]
+        def __getitem__(self, key):
+            return self._mapping[key]
 
-    def __contains__(self, key):
-        return key in self._mapping
+        def __contains__(self, key):
+            return key in self._mapping
 
-    def __len__(self):
-        return len(self._mapping)
+        def __len__(self):
+            return len(self._mapping)
 
-    def __iter__(self):
-        return iter(self._mapping)
+        def __iter__(self):
+            return iter(self._mapping)
 
-    def set(self, key, value):
-        copy = _ContextData()
-        copy._mapping = self._mapping.copy()
-        copy._mapping[key] = value
-        return copy
+        def set(self, key, value):
+            copy = _ContextData()
+            copy._mapping = self._mapping.copy()
+            copy._mapping[key] = value
+            return copy
 
-    def delete(self, key):
-        copy = _ContextData()
-        copy._mapping = self._mapping.copy()
-        del copy._mapping[key]
-        return copy
+        def delete(self, key):
+            copy = _ContextData()
+            copy._mapping = self._mapping.copy()
+            del copy._mapping[key]
+            return copy
 
 
 class ContextMeta(type(collections.abc.Mapping)):

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     author_email='hello@magic.io',
     packages=['contextvars'],
     provides=['contextvars'],
+    extras_require=dict(HAMT='immutables'),
     license='Apache License, Version 2.0',
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Using `extras_require` here in case someone in Python 3.6 still want the underlying storage mutable somehow, or couldn't install immutables for whatever reasons. Please let me know if you prefer using a hard dependency instead of an optional one.